### PR TITLE
Added min Cython version 0.19.1 as requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     description = 'Python binding for Raspberry Pi GPU FFTerface',
     long_description = README,
     install_requires=[
-          'cython',
+          'cython>=0.19.1',
           'numpy',
       ],
     cmdclass={'build_ext': build_ext},


### PR DESCRIPTION
Raspbian Wheezy uses Cython 0.15.1 rpi-audio-level will not compile with this version.  This triggers installing a newer version
